### PR TITLE
Adding support for multiple interfaces in Kea

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ kea_build_path: "{{kea_path}}/build"
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""
-kea_dhcp_listen_iface: ""
+kea_dhcp_listen_ifaces: []
 kea_subnets: []
 kea_mr_provisioner_plugin_version: "0.1"
 kea_mr_provisioner_public_addr: ""

--- a/templates/kea-dhcp4.service.j2
+++ b/templates/kea-dhcp4.service.j2
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/opt/kea/sbin/kea-dhcp4 -c /etc/kea.conf
+ExecStart={{kea_path}}/sbin/kea-dhcp4 -c {{kea_conf}}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/kea-dhcp4.service.j2
+++ b/templates/kea-dhcp4.service.j2
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart={{kea_path}}/sbin/kea-dhcp4 -c {{kea_conf}}
+ExecStart={{kea_path}}/sbin/kea-dhcp4 -c {{kea_config}}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -1,6 +1,6 @@
 { "Dhcp4": {
     "interfaces-config": {
-        "interfaces": [ {% for iface in kea_dhcp_listen_ifaces %}"{{iface}}"{% endfor %} ],
+        "interfaces": [ {% for iface in kea_dhcp_listen_ifaces %}"{{iface}}"{% if not loop.last %}, {% endif %}{% endfor %} ],
         "dhcp-socket-type": "raw"
     },
     "valid-lifetime": 3600,

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -1,6 +1,6 @@
 { "Dhcp4": {
     "interfaces-config": {
-        "interfaces": [ "{{kea_dhcp_listen_iface}}" ],
+        "interfaces": [ {% for iface in kea_dhcp_listen_ifaces %}"{{iface}}"{% endfor %} ],
         "dhcp-socket-type": "raw"
     },
     "valid-lifetime": 3600,
@@ -10,6 +10,7 @@
     {% for subnet in kea_subnets %}
        {
             "subnet": "{{subnet.subnet}}",
+	    {% if subnet.interface %}"interface": "{{subnet.interface}}", {% endif %}
             "pools": [
              {% for pool in subnet.pools %}
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -30,7 +30,7 @@
     ],
     "hooks-libraries": [
         {
-            "library": "/opt/kea/lib/libkea-hook-mr-provisioner.so",
+            "library": "{{kea_path}}/lib/libkea-hook-mr-provisioner.so",
             "parameters": {
                 "provisioner_url": "http://{{kea_mr_provisioner_public_addr}}:{{kea_mr_provisioner_public_port}}/dhcp",
                 "timeout_ms": 5000
@@ -45,7 +45,7 @@
             "name": "kea-dhcp4.leases",
             "output_options": [
                 {
-                    "output": "/opt/kea/logs/kea-leases.log",
+                    "output": "{{kea_path}}/logs/kea-leases.log",
                     "maxver": 8,
                     "maxsize": 204800,
                     "flush": true
@@ -57,7 +57,7 @@
             "name": "kea-dhcp4.packets",
             "output_options": [
                 {
-                    "output": "/opt/kea/logs/kea-packets.log",
+                    "output": "{{kea_path}}/logs/kea-packets.log",
                     "maxver": 8,
                     "maxsize": 204800,
                     "flush": true

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -10,7 +10,7 @@
     {% for subnet in kea_subnets %}
        {
             "subnet": "{{subnet.subnet}}",
-	    {% if subnet.interface %}"interface": "{{subnet.interface}}", {% endif %}
+	    {% if subnet.interface is defined %}"interface": "{{subnet.interface}}", {% endif %}
             "pools": [
              {% for pool in subnet.pools %}
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}


### PR DESCRIPTION
This allows the configuration of multiple interfaces on which Kea can listen on. It also adds the possibility to assign each interface to the subnets defined in the kea.conf file.

### I forgot to rebase my branch on main instead of my fixes... Sorry about that !