### PR TITLE
Adding support for hard-coded reservations in Kea configuration

### DIFF
--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -14,8 +14,8 @@
              {% for pool in subnet.pools %}
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}
              {% endfor %}
-            ],
-	{% if subnet.reservations is defined %}"reservations": [
+            ]{% if subnet.reservations is defined %},
+	    "reservations": [
 	{% for reservation in subnet.reservations %}
 	     {
 		"hw-address": "{{reservation.macaddress}}"

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -14,7 +14,15 @@
              {% for pool in subnet.pools %}
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}
              {% endfor %}
-            ]
+            ],
+	{% if subnet.reservations %}"reservations": [
+	{% for reservation in subnet.reservations %}
+	     {
+		"hw-address": "{{reservation.macaddress}}"
+		"ip-address": "{{reservation.ipaddress}}"
+	     }{% if not loop.last %},{% endif %}
+        {% endfor %}
+	]{% endif %}
        }{% if not loop.last %}, {%endif%}
     {% endfor %}
     ],

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -15,7 +15,7 @@
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}
              {% endfor %}
             ],
-	{% if subnet.reservations %}"reservations": [
+	{% if subnet.reservations is defined %}"reservations": [
 	{% for reservation in subnet.reservations %}
 	     {
 		"hw-address": "{{reservation.macaddress}}"


### PR DESCRIPTION
This adds the possibility for hard-coded reservations in the kea.conf

To do this simply add in the yaml ansible playbook definition file: 
- kea_subnets:
    - subnet : "whatever"
      interface: "ens1"
      pools:
        -"wherever:wherever"
<b>      reservations:
        - macaddress: "00:00:00:00:00"
          ipaddress: "192.168.1.1" 
        - macaddress: "12:34:45:65:78"
          ipaddress: "192.168.1.2"

Be careful of the placement of the dash : on macaddress only !</b>
(It defines the start of an array in YAML, here an array of dictionaries.)
      