### PR TITLE
Added support for kea install via deb package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ kea_services:
 kea_config: "/etc/kea.conf"
 kea_path: "/opt/kea"
 kea_build_path: "{{kea_path}}/build"
-kea_aptinstall: "False"
+kea_aptinstall: False
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ kea_services:
 kea_config: "/etc/kea.conf"
 kea_path: "/opt/kea"
 kea_build_path: "{{kea_path}}/build"
+kea_aptinstall: "False"
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,6 @@
     name: "{{item}}"
     update_cache: yes
   with_items:
-    - sudo
     - build-essential
     - libssl-dev
     - liblog4cplus-dev

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: Install KEA via apt
   shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install -y ./{{kea_deb_pkg_name}}"
-  when: kea_aptinstall
+  when: kea.stat.exists == False and kea_aptinstall
 
 - name: Fetch mr-provisioner KEA plugin
   unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     name: "{{item}}"
     update_cache: yes
   with_items:
+    - sudo
     - build-essential
     - libssl-dev
     - liblog4cplus-dev
@@ -19,6 +20,9 @@
     - "{{kea_build_path}}"
     - "{{kea_path}}/bin"
     - "{{kea_path}}/logs"
+    - "{{kea_path}}/var"
+    - "{{kea_path}}/var/run/kea"
+    - "{{kea_path}}/var/kea"
 
 - name: Check public addr
   set_fact:
@@ -36,17 +40,17 @@
     remote_src: yes
   with_items:
     - "https://ftp.isc.org/isc/kea/{{kea_version}}/kea-{{kea_version}}.tar.gz"
-  when: kea.stat.exists == False and kea_aptinstall == False
+  when: kea.stat.exists == False
 
 - name: Build and install KEA
   shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j && make install"
   register: build
   fail_when: build.rc != 0
-  when: kea.stat.exists == False and kea_aptinstall == False
+  when: kea.stat.exists == False and not kea_aptinstall 
 
 - name: Install KEA via apt
-  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install ./{{kea_deb_pkg_name}}"
-  when: kea_aptinstall == True
+  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install -y ./{{kea_deb_pkg_name}}"
+  when: kea_aptinstall
 
 - name: Fetch mr-provisioner KEA plugin
   unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
     - "{{kea_build_path}}"
     - "{{kea_path}}/bin"
     - "{{kea_path}}/logs"
+    - "{{kea_path}}/var"
+    - "{{kea_path}}/var/run/kea"
+    - "{{kea_path}}/var/kea"
 
 - name: Check public addr
   set_fact:
@@ -36,17 +39,17 @@
     remote_src: yes
   with_items:
     - "https://ftp.isc.org/isc/kea/{{kea_version}}/kea-{{kea_version}}.tar.gz"
-  when: kea.stat.exists == False and kea_aptinstall == False
+  when: kea.stat.exists == False
 
 - name: Build and install KEA
   shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j && make install"
   register: build
   fail_when: build.rc != 0
-  when: kea.stat.exists == False and kea_aptinstall == False
+  when: kea.stat.exists == False and not kea_aptinstall 
 
 - name: Install KEA via apt
-  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install ./{{kea_deb_pkg_name}}"
-  when: kea_aptinstall == True
+  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install -y ./{{kea_deb_pkg_name}}"
+  when: kea_aptinstall
 
 - name: Fetch mr-provisioner KEA plugin
   unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,13 +36,17 @@
     remote_src: yes
   with_items:
     - "https://ftp.isc.org/isc/kea/{{kea_version}}/kea-{{kea_version}}.tar.gz"
-  when: kea.stat.exists == False
+  when: kea.stat.exists == False and kea_aptinstall == False
 
 - name: Build and install KEA
   shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j && make install"
   register: build
   fail_when: build.rc != 0
-  when: kea.stat.exists == False
+  when: kea.stat.exists == False and kea_aptinstall == False
+
+- name: Install KEA via apt
+  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install ./{{kea_deb_pkg_name}}"
+  when: kea_aptinstall == True
 
 - name: Fetch mr-provisioner KEA plugin
   unarchive:


### PR DESCRIPTION
Adds support for the download and apt install of a deb package, instead of building kea each time.

The hook still needs to be built though, so the large dependencies are still required.
I'm working on also having a deb for the hook, merge request pending.

(Please disregard commits 5dfe2a0 and 99e5e16 , as I messed up my commit amend : I just wanted to delete sudo as a dependency, as it isn't, it's a MrP one)

Note : the deb package does not create /opt/kea/var/blabla directories... and without them Kea cannot create the lockfiles 