### PR TITLE
Fixed incorrect gateways and DNS assigning per subnet

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ kea_build_path: "{{kea_path}}/build"
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""
+kea_validlifetime: "3600"
+kea_renewtimer: "1000"
+kea_rebindtimer: "2000"
 kea_dhcp_listen_ifaces: []
 kea_subnets: []
 kea_mr_provisioner_plugin_version: "0.1"

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -3,9 +3,9 @@
         "interfaces": [ {% for iface in kea_dhcp_listen_ifaces %}"{{iface}}"{% if not loop.last %}, {% endif %}{% endfor %} ],
         "dhcp-socket-type": "raw"
     },
-    "valid-lifetime": 3600,
-    "renew-timer": 1000,
-    "rebind-timer": 2000,
+    "valid-lifetime": {{kea_validlifetime}},
+    "renew-timer": {{kea_renewtimer}},
+    "rebind-timer": {{kea_rebindtimer}},
     "subnet4": [
     {% for subnet in kea_subnets %}
        {
@@ -15,6 +15,16 @@
              {% for pool in subnet.pools %}
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}
              {% endfor %}
+	    			],
+			"option-data": [
+				{
+					"name": "domain-name-servers",
+					"data": "{{subnet.nameservers|default(kea_nameservers)}}"
+				},
+				{
+					"name": "routers",
+					"data": "{{subnet.default_gateway|default(kea_default_gateway)}}"
+				}
             ]{% if subnet.reservations is defined %},
 	    "reservations": [
 	{% for reservation in subnet.reservations %}


### PR DESCRIPTION
Added support to the config for proper configuration of each subnets : adding dns and gateway/routers per Kea subnets.

Also added support for valid lifetime, renew timer and rebind timer definition.

<b>NOTE :</b> Additional options are possible : http://kea.isc.org/docs/kea-guide.html#dhcp4-std-options-list. This can also be added, at the expense of less readability in the playbook/vars.