### PR TITLE
Added support for Hook Debian Package install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ kea_aptinstall: "False"
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""
+kea_validlifetime: "3600"
+kea_renewtimer: "1000"
+kea_rebindtimer: "2000"
 kea_dhcp_listen_ifaces: []
 kea_subnets: []
 kea_mr_provisioner_plugin_version: "0.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ kea_services:
 kea_config: "/etc/kea.conf"
 kea_path: "/opt/kea"
 kea_build_path: "{{kea_path}}/build"
-kea_aptinstall: "False"
+kea_aptinstall: False
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ kea_config: "/etc/kea.conf"
 kea_path: "/opt/kea"
 kea_build_path: "{{kea_path}}/build"
 kea_aptinstall: False
+kea_hook_aptinstall: False
 kea_log_level: "DEBUG"
 kea_nameservers: ""
 kea_default_gateway: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,9 @@
     - "{{kea_build_path}}"
     - "{{kea_path}}/bin"
     - "{{kea_path}}/logs"
+    - "{{kea_path}}/var"
+    - "{{kea_path}}/var/run/kea"
+    - "{{kea_path}}/var/kea"
 
 - name: Check public addr
   set_fact:
@@ -36,17 +39,17 @@
     remote_src: yes
   with_items:
     - "https://ftp.isc.org/isc/kea/{{kea_version}}/kea-{{kea_version}}.tar.gz"
-  when: kea.stat.exists == False and kea_aptinstall == False
+  when: kea.stat.exists == False
 
 - name: Build and install KEA
   shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j && make install"
   register: build
   fail_when: build.rc != 0
-  when: kea.stat.exists == False and kea_aptinstall == False
+  when: kea.stat.exists == False and not kea_aptinstall 
 
 - name: Install KEA via apt
-  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install ./{{kea_deb_pkg_name}}"
-  when: kea_aptinstall == True
+  shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install -y ./{{kea_deb_pkg_name}}"
+  when: kea_aptinstall
 
 - name: Fetch mr-provisioner KEA plugin
   unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
     - liblog4cplus-dev
     - libcurl4-openssl-dev
     - libboost-all-dev
+  when: not kea_aptinstall and not kea_hook_aptinstall
 
 - name: Create required directories
   file:
@@ -49,7 +50,7 @@
 
 - name: Install KEA via apt
   shell: "cd {{kea_build_path}} && wget {{kea_deb_pkg_html}} && apt install -y ./{{kea_deb_pkg_name}}"
-  when: kea_aptinstall
+  when: kea.stat.exists == False and kea_aptinstall
 
 - name: Fetch mr-provisioner KEA plugin
   unarchive:
@@ -58,6 +59,7 @@
     remote_src: yes
   with_items:
     - "https://github.com/Linaro/mr-provisioner-kea/archive/v{{kea_mr_provisioner_plugin_version}}.tar.gz"
+  when: not kea_hook_aptinstall
 
 - name: Build and install mr-provisioner KEA plugin
   make:
@@ -66,6 +68,11 @@
     params:
       KEA_SRC: "{{kea_build_path}}/kea-{{kea_version}}"
       KEA_PREFIX: "{{kea_path}}"
+  when: not kea_hook_aptinstall
+
+- name: Install KEA MrP hook via apt
+  shell: "cd {{kea_build_path}} && wget {{kea_hook_repo}} && apt install -y ./{{kea_hook_deb_pkg_name}}"
+  when: kea_hook_aptinstall
 
 - name: Generate configuration files for KEA
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
     - liblog4cplus-dev
     - libcurl4-openssl-dev
     - libboost-all-dev
+  when: not kea_aptinstall and not kea_hook_aptinstall
 
 - name: Create required directories
   file:
@@ -58,6 +59,7 @@
     remote_src: yes
   with_items:
     - "https://github.com/Linaro/mr-provisioner-kea/archive/v{{kea_mr_provisioner_plugin_version}}.tar.gz"
+  when: not kea_hook_aptinstall
 
 - name: Build and install mr-provisioner KEA plugin
   make:
@@ -66,6 +68,11 @@
     params:
       KEA_SRC: "{{kea_build_path}}/kea-{{kea_version}}"
       KEA_PREFIX: "{{kea_path}}"
+  when: not kea_hook_aptinstall
+
+- name: Install KEA MrP hook via apt
+  shell: "cd {{kea_build_path}} && wget {{kea_hook_repo}} && apt install -y ./{{kea_hook_deb_pkg_name}}"
+  when: kea_hook_aptinstall
 
 - name: Generate configuration files for KEA
   template:

--- a/templates/kea.conf.j2
+++ b/templates/kea.conf.j2
@@ -3,9 +3,9 @@
         "interfaces": [ {% for iface in kea_dhcp_listen_ifaces %}"{{iface}}"{% if not loop.last %}, {% endif %}{% endfor %} ],
         "dhcp-socket-type": "raw"
     },
-    "valid-lifetime": 3600,
-    "renew-timer": 1000,
-    "rebind-timer": 2000,
+    "valid-lifetime": {{kea_validlifetime}},
+    "renew-timer": {{kea_renewtimer}},
+    "rebind-timer": {{kea_rebindtimer}},
     "subnet4": [
     {% for subnet in kea_subnets %}
        {
@@ -15,6 +15,16 @@
              {% for pool in subnet.pools %}
              { "pool": "{{pool|string}}" } {% if not loop.last %}, {% endif %}
              {% endfor %}
+	    			],
+			"option-data": [
+				{
+					"name": "domain-name-servers",
+					"data": "{{subnet.nameservers|default(kea_nameservers)}}"
+				},
+				{
+					"name": "routers",
+					"data": "{{subnet.default_gateway|default(kea_default_gateway)}}"
+				}
             ]{% if subnet.reservations is defined %},
 	    "reservations": [
 	{% for reservation in subnet.reservations %}


### PR DESCRIPTION
As compiling the Kea Hook requires sources and build-essential, I added the support for it to be installed by apt like Kea itself.

### Note: Ignore the options-data thing, it is already present on the master (after merge of pull request #6 ) and should not be shown in green...